### PR TITLE
Gestion de navigation + blocage de modification des stratigraphies + fix bugs

### DIFF
--- a/micorr/artefacts/views.py
+++ b/micorr/artefacts/views.py
@@ -1563,7 +1563,8 @@ class PublicationArtefactDetailView(generic.DetailView):
         context = super(PublicationArtefactDetailView, self).get_context_data(**kwargs)
         publication = get_object_or_404(Publication, pk=self.kwargs['pk'])
         artefact = publication.artefact
-        if artefact.object.user != self.request.user :
+        typeUser = adminType(self.request.user)
+        if artefact.object.user != self.request.user and typeUser==None :
             raise Http404
         sections = artefact.section_set.all()
         documents = artefact.document_set.all()

--- a/micorr/templates/artefacts/artefact_administration_detail.html
+++ b/micorr/templates/artefacts/artefact_administration_detail.html
@@ -41,7 +41,7 @@
             {% endfor %}
         </ul>
         {% endif %}
-
+      <a href="{% url 'artefacts:publication-administration-menu' %}" class="btn btn-primary btn-md">Return to Administration menu</a><br><br>
       <h1>{{ artefact.artefact_verbose_description_short }}</h1>
           {% if accessType == 'answermain' %}
               <div class="row">

--- a/micorr/templates/artefacts/artefact_detail_body.html
+++ b/micorr/templates/artefacts/artefact_detail_body.html
@@ -198,7 +198,7 @@
         <div class="c3"><em>Stratigraphies</em></div>
         <div class="c9">
             {% for stratigraphy in stratigraphies %}
-                <p><a href="/micorr/#/stratigraphy/{{ stratigraphy.uid }}" target="_blank"><img src="{{ node_base_url }}getStratigraphySvg?name={{ stratigraphy.uid }}&width=300" class="img-responsive"></a></p>
+                <p><img src="{{ node_base_url }}getStratigraphySvg?name={{ stratigraphy.uid }}&width=300" class="img-responsive"></p>
             {% empty %}
                 <p>None</p>
             {% endfor %}

--- a/micorr/templates/artefacts/artefact_publication_detail.html
+++ b/micorr/templates/artefacts/artefact_publication_detail.html
@@ -42,6 +42,7 @@
         </ul>
         {% endif %}
 
+      <a href="{% url 'artefacts:publication-menu' %}" class="btn btn-primary btn-md">Return to Publication menu</a><br><br>
       <h1>{{ artefact.artefact_verbose_description_short }}</h1>
       {% if publication.decision_taken %}
           <div class="row">

--- a/micorr/templates/artefacts/collaboration_artefact_update.html
+++ b/micorr/templates/artefacts/collaboration_artefact_update.html
@@ -38,7 +38,9 @@
 {% endblock sidemenu %}
 
 {% block content %}
-
+    <div class="row">
+        <a href="{% url 'artefacts:collaboration_menu' %}" class="btn btn-primary btn-md">Return to collaboration menu</a><br><br>
+    </div>
     <h1>Update artefact</h1>
     <form action="{% url 'artefacts:artefact-update' form.instance.pk %}" method="post">{% csrf_token %}
         {% if form.errors %}

--- a/micorr/templates/artefacts/collaboration_comment_form.html
+++ b/micorr/templates/artefacts/collaboration_comment_form.html
@@ -46,18 +46,23 @@
             {% endfor %}
         </ul>
         {% endif %}
-
+      <div class="row">
+          <a href="{% url 'artefacts:collaboration_menu' %}" class="btn btn-primary btn-md">Return to collaboration menu</a><br><br>
+      </div>
       <h1>{{ artefact.artefact_verbose_description_short }}</h1>
 
         <div class="row">
           <div class="c2"><em>Authors</em></div>
           <div class="c10"><p>{{ artefact.get_authors }}</p></div>
         </div>
-            <div class="row">
+        <div class="row">
+            <form action="{% url 'artefacts:send-comments' token_id=token.id %}" method="post">{% csrf_token %}
+                <a href="{% url 'artefacts:read-comments' pk=token.id %}" class="btn btn-primary btn-md"><i class="fa fa-eye"></i>&nbsp;&nbsp;I have read all comments</a>
                 <div class="pull-right">
-                    <a href="{% url 'artefacts:read-comments' pk=token.id %}" class="btn btn-primary btn-md"><i class="fa fa-eye"></i>&nbsp;&nbsp;I have read all comments</a>
+                    <button class="btn btn-primary btn-md" type="submit" onclick="return confirm('Are you sure you want to send comments? You will not be allowed to delete sent comments')"><i class="fa fa-paper-plane"></i>&nbsp;&nbsp;Send comments</button>
                 </div>
-            </div>
+            </form>
+        </div>
         <br>
         <div  id="accordionN1" aria-multiselectable="true">
 
@@ -1312,8 +1317,9 @@
         <br>
         <form action="{% url 'artefacts:send-comments' token_id=token.id %}" method="post">{% csrf_token %}
             <div class="row">
+                <a href="{% url 'artefacts:read-comments' pk=token.id %}" class="btn btn-primary btn-md"><i class="fa fa-eye"></i>&nbsp;&nbsp;I have read all comments</a>
                 <div class="pull-right">
-                    <button class="btn btn-primary btn-lg" type="submit" onclick="return confirm('Are you sure you want to send comments? You will not be allowed to delete sent comments')"><i class="fa fa-paper-plane"></i>&nbsp;&nbsp;Send comments</button>
+                    <button class="btn btn-primary btn-md" type="submit" onclick="return confirm('Are you sure you want to send comments? You will not be allowed to delete sent comments')"><i class="fa fa-paper-plane"></i>&nbsp;&nbsp;Send comments</button>
                 </div>
             </div>
         </form>

--- a/micorr/templates/artefacts/collaboration_comment_form.html
+++ b/micorr/templates/artefacts/collaboration_comment_form.html
@@ -923,7 +923,7 @@
                 <div class="c3"><em>Stratigraphies</em></div>
                 <div class="c8">
                     {% for stratigraphy in stratigraphies %}
-                        <p><a href="/micorr/#/stratigraphy/{{ stratigraphy.uid }}" target="_blank"><img src="{{ node_base_url }}getStratigraphySvg?name={{ stratigraphy.uid }}&width=300" class="img-responsive"></a></p>
+                        <p><img src="{{ node_base_url }}getStratigraphySvg?name={{ stratigraphy.uid }}&width=300" class="img-responsive"></p>
                     {% empty %}
                         <p>None</p>
                     {% endfor %}

--- a/micorr/templates/artefacts/publication_administration_menu.html
+++ b/micorr/templates/artefacts/publication_administration_menu.html
@@ -54,7 +54,7 @@
                                                     <td>{{ request.created }}</td>
                                                     <td>{{ request.artefact.object.name }}</td>
                                                     <td>{{ request.artefact.object.user.username }}</td>
-                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=request.id accessType='answermain' %}" target="_blank"><i class="fa fa-eye"></i></a></td>
+                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=request.id accessType='answermain' %}"><i class="fa fa-eye"></i></a></td>
                                                 </tr>
                                             {% endfor %}
                                         </table>
@@ -98,7 +98,7 @@
                                                     {% else %}
                                                         <td><i class="fa fa-times" style="color: red"></i></td>
                                                     {% endif %}
-                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=delegPubConf.id accessType='confirm' %}" target="_blank"><i class="fa fa-eye"></i></a></td>
+                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=delegPubConf.id accessType='confirm' %}"><i class="fa fa-eye"></i></a></td>
                                                 </tr>
                                             {% endfor %}
                                         </table>
@@ -171,7 +171,7 @@
                                                     <td>{{ delegrequest.created }}</td>
                                                     <td>{{ delegrequest.artefact.object.name }}</td>
                                                     <td>{{ delegrequest.artefact.object.user.username }}</td>
-                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=delegrequest.id accessType='answerdeleg' %}" target="_blank"><i class="fa fa-eye"></i></a></td>
+                                                    <td><a href="{% url 'artefacts:publication-administration-detail' pk=delegrequest.id accessType='answerdeleg' %}"><i class="fa fa-eye"></i></a></td>
                                                 </tr>
                                             {% endfor %}
                                         </table>
@@ -182,6 +182,8 @@
                             </div>
                         </div>
                     {% endif %}
+                    <br>
+                    <a href="{% url 'artefacts:publication-menu' %}" class="btn btn-primary btn-md">Return to Publication menu</a>
                 </div>
             </div>
         {% endif %}

--- a/micorr/templates/artefacts/publication_menu.html
+++ b/micorr/templates/artefacts/publication_menu.html
@@ -7,7 +7,6 @@
 
         <div class="row">
             <div class="col-sm-12">
-
                 <h2>{{ user.username|capfirst }}</h2>
                 <h3>Publications
                     {% if isAdmin %}
@@ -145,7 +144,7 @@
                                                 {% else %}
                                                     <td><i class="fa fa-times" style="color: red"></i></td>
                                                 {% endif %}
-                                                <td><a href="{% url 'artefacts:publication-artefact-detail' pk=pubHist.id %}" target="_blank"><i class="fa fa-eye"></i></a></td>
+                                                <td><a href="{% url 'artefacts:publication-artefact-detail' pk=pubHist.id %}"><i class="fa fa-eye"></i></a></td>
                                             </tr>
                                         {% endfor %}
                                     </table>
@@ -155,6 +154,8 @@
                             </div>
                         </div>
                     </div>
+                    <br>
+                    <a href="{% url 'users:detail' username=user %}" class="btn btn-primary btn-md">Return to My Profile</a>
                 </div>
             </div>
         {% endif %}

--- a/micorr/templates/artefacts/token_collaboration_menu.html
+++ b/micorr/templates/artefacts/token_collaboration_menu.html
@@ -7,7 +7,6 @@
 
         <div class="row">
             <div class="col-sm-12">
-
                 <h2>{{ user.username|capfirst }}</h2>
                 <h3>Collaborations</h3>
                 <br>
@@ -147,6 +146,7 @@
                         </div>
                     </div>
                     <br>
+                    <a href="{% url 'users:detail' username=user %}" class="btn btn-primary btn-md">Return to My Profile</a>
                     <div class="pull-right">
                         <a href="{% url 'artefacts:collaboration_deleted_menu' %}" class="btn btn-primary btn-md"><i class="fa fa-recycle"></i> Retrieve deleted collaborations</a>
                     </div>


### PR DESCRIPTION
- Ajout de boutons permettant de naviguer entre les menus (permet un rafraîchissement et une mise à jour du système de notifications)
- Blocage au niveau des stratigraphies qui pouvaient être modifier lors de la collaboration (par le collaborateur) et de la publication (par les administrateurs)
- Correction d'un bug empêchant l'administrateur principal de visualiser les demandes des autres auteurs déléguées et en cours de progression