### PR TITLE
Modification d'URL + blocage des modifications par un collaborateur

### DIFF
--- a/micorr/artefacts/urls.py
+++ b/micorr/artefacts/urls.py
@@ -81,9 +81,9 @@ urlpatterns = [
     url(r'^publication/(?P<pk>\d+)/$', login_required(artefacts_views.PublicationArtefactDetailView.as_view()), name='publication-artefact-detail'),
     url(r'^administration/$', login_required(artefacts_views.AdministrationListView.as_view()), name='publication-administration-menu'),
     url(r'^administration/(?P<pk>\d+)/(?P<accessType>\w+)/$', login_required(artefacts_views.AdministrationArtefactDetailView.as_view()), name='publication-administration-detail'),
-    url(r'^administration/(?P<pk>\d+)/decision/$', login_required(artefacts_views.PublicationUpdateDecision.as_view()), name='publication-administration-decision'),
-    url(r'^administration/(?P<publication_id>\d+)/confirm/$', login_required(artefacts_views.confirmDecisionDelegatedAdmin), name='publication-administration-confirm'),
-    url(r'^administration/(?P<pk>\d+)/reject/$', login_required(artefacts_views.PublicationDecisionReject.as_view()), name='publication-administration-reject'),
-    url(r'^administration/(?P<pk>\d+)/delegate/$', login_required(artefacts_views.PublicationDelegateView.as_view()), name='publication-administration-delegate'),
+    url(r'^administration/decision/(?P<pk>\d+)/$', login_required(artefacts_views.PublicationUpdateDecision.as_view()), name='publication-administration-decision'),
+    url(r'^administration/confirm/(?P<publication_id>\d+)/$', login_required(artefacts_views.confirmDecisionDelegatedAdmin), name='publication-administration-confirm'),
+    url(r'^administration/reject/(?P<pk>\d+)/$', login_required(artefacts_views.PublicationDecisionReject.as_view()), name='publication-administration-reject'),
+    url(r'^administration/delegate/(?P<pk>\d+)/$', login_required(artefacts_views.PublicationDelegateView.as_view()), name='publication-administration-delegate'),
     # url(r'^test-ontology/$', displayOntology),
 ]

--- a/micorr/artefacts/views.py
+++ b/micorr/artefacts/views.py
@@ -441,7 +441,8 @@ def shareArtefact(request, artefact_id):
             if right == 'R':
                 link = request.get_host() + '/artefacts/' + artefact_id + '/?token='+token.uuid
             elif right == 'W':
-                link = request.get_host() + '/artefacts/' + artefact_id + '/update/?token='+token.uuid
+                #link = request.get_host() + '/artefacts/' + artefact_id + '/update/?token='+token.uuid
+                link = request.get_host() + '/artefacts/collaboration/'
 
             token.link = link
             token.save()

--- a/micorr/templates/artefacts/publication_decision_form.html
+++ b/micorr/templates/artefacts/publication_decision_form.html
@@ -48,7 +48,10 @@
                 </div>
                 <div class="row">
                     <br>
-                    <div class="col-sm-1 col-sm-offset-9">
+                    <div class="col-sm-1">
+                        <a href="{% url 'artefacts:publication-administration-menu' %}" class="btn btn-md btn-primary">Cancel</a>
+                    </div>
+                    <div class="col-sm-1 col-sm-offset-8">
                         <div class="pull-right">
                             <button class="btn btn-danger btn-md" type="submit" name="refuse" onclick="return confirm('Are you sure you want to refuse the request?')"><i class="fa fa-times"></i> Refuse</button>
                         </div>


### PR DESCRIPTION
- Modification d'URL pour la prise de décision de l'admin principal qui renvoyait sur la mauvaise page après un premier changement dans ce même URL
- Modification du lien envoyé dans l'email lors de collaboration avec droit d'écriture qui empêche le collaborateur de directement modifier la fiche artefact (désormais, le système choisi est le commentaire)